### PR TITLE
Rework deactivated and banned user states

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -13,7 +13,7 @@ class Admin::UsersController < ApplicationController
 
         redirect_to profile_path(@user.id), notice: "Generated #{count} invite codes for #{@user.username}."
     end
-
+    
     def ban
         if @user == current_user
             return redirect_to profile_path(@user.id), alert: "You cannot ban yourself."
@@ -21,6 +21,21 @@ class Admin::UsersController < ApplicationController
 
         if @user.admin?
             return redirect_to profile_path(@user.id), alert: "You cannot ban another admin."
+        end
+
+        reason = params[:reason].to_s.strip.presence || "No reason provided"
+
+        @user.update(role: :banned, ban_reason: reason)
+        redirect_to profile_path(@user.id), notice: "User has been banned."
+    end
+
+    def nuke
+        if @user == current_user
+            return redirect_to profile_path(@user.id), alert: "You cannot nuke yourself."
+        end
+
+        if @user.admin?
+            return redirect_to profile_path(@user.id), alert: "You cannot nuke another admin."
         end
 
         Users::Anonymize.call(user: @user)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -13,7 +13,7 @@ class Admin::UsersController < ApplicationController
 
         redirect_to profile_path(@user.id), notice: "Generated #{count} invite codes for #{@user.username}."
     end
-    
+
     def ban
         if @user == current_user
             return redirect_to profile_path(@user.id), alert: "You cannot ban yourself."

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
 
-  helper_method :current_user, :signed_in?, :admin?
+  helper_method :current_user, :signed_in?, :admin?, :activated_user?
 
   before_action :load_current_user
 
@@ -43,6 +43,10 @@ class ApplicationController < ActionController::Base
   def require_activated!
     activated = signed_in? && ([ :user, :pro, :admin ].include? current_user.role)
     redirect_to root_path, alert: "Your account does not have permission to perform this action." unless activated
+  end
+
+  def activated_user?(user)
+    user.present? && [ :user, :pro, :admin ].include?(user.role)
   end
 
   def admin?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,12 +41,12 @@ class ApplicationController < ActionController::Base
   end
 
   def require_activated!
-    activated = signed_in? && ([ :user, :pro, :admin ].include? current_user.role)
+    activated = signed_in? && activated_user?(current_user)
     redirect_to root_path, alert: "Your account does not have permission to perform this action." unless activated
   end
 
   def activated_user?(user)
-    user.present? && [ :user, :pro, :admin ].include?(user.role)
+    user.present? && user.activated?
   end
 
   def admin?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,11 @@ class ApplicationController < ActionController::Base
     redirect_to login_path, alert: "Please log in" unless signed_in?
   end
 
+  def require_activated!
+    activated = signed_in? && ([ :user, :pro, :admin ].include? current_user.role)
+    redirect_to root_path, alert: "Your account does not have permission to perform this action." unless activated
+  end
+
   def admin?
     current_user&.admin?
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,10 @@
 class HomeController < ApplicationController
   def index
-    @latest_pastes = Paste.open.order(created_at: :desc).limit(10)
+    @latest_pastes = Paste.open
+                          .joins(:user)
+                          .merge(User.activated)
+                          .order(created_at: :desc)
+                          .limit(10)
 
     if signed_in?
       @paste = current_user.pastes.new

--- a/app/controllers/pastes_controller.rb
+++ b/app/controllers/pastes_controller.rb
@@ -1,6 +1,7 @@
 class PastesController < ApplicationController
   include TagsHelper
   before_action :require_login!, except: [ :show, :raw, :index ]
+  before_action :require_activated!, except: [ :show, :raw, :index ]
   before_action :set_paste_by_id, only: [ :edit, :update, :destroy ]
   before_action :set_paste_by_shortcode, only: [ :show, :raw ]
 

--- a/app/controllers/pastes_controller.rb
+++ b/app/controllers/pastes_controller.rb
@@ -56,7 +56,7 @@ class PastesController < ApplicationController
   end
 
   def index
-    pastes_scope = Paste.where(visibility: :open)
+    pastes_scope = Paste.where(visibility: :open).joins(:user).where(users: { role: User::ACTIVATED_ROLES })
 
     @all_tags = pastes_scope
       .where.not(tags: nil)
@@ -122,8 +122,8 @@ class PastesController < ApplicationController
   end
 
   def authorize_view!(paste)
-    return if paste.open? || paste.unlisted?
-    return if current_user == paste.user || current_user&.admin?
+    should_show = (paste.user.activated?) && (paste.open? || paste.unlisted? || current_user == paste.user || current_user&.admin?)
+    return if should_show
 
     raise ActiveRecord::RecordNotFound
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -6,6 +6,10 @@ class ProfilesController < ApplicationController
 
     raise ActiveRecord::RecordNotFound unless @user.present? && !@user.anonymized_at.present?
 
+    if @user.inactive? && current_user != @user && !current_user&.admin?
+      raise ActiveRecord::RecordNotFound
+    end
+
     if current_user&.admin? || current_user == @user
       @invite_codes = InviteCode.where(created_by_id: @user.id).order(created_at: :desc)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   validates :username, presence: true, uniqueness: { case_sensitive: false }, length: { in: 3..20 },
     format: { with: /\A(?!\d+\z)[a-zA-Z0-9_]+\z/, message: "May only contain letters (at least one), numbers, and underscores and must be between 3 and 20 characters long." }
 
-  enum :role, { user: 0, pro: 1, admin: 999 }, default: :user
+  enum :role, { user: 0, pro: 1, deactivated: 2, banned: 3, admin: 999 }, default: :user
 
   def build_scratchpad
     scratchpad || create_scratchpad

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,22 @@ class User < ApplicationRecord
 
   enum :role, { user: 0, pro: 1, deactivated: 2, banned: 3, admin: 999 }, default: :user
 
+  ACTIVATED_ROLES = %w[user pro admin].freeze
+  INACTIVE_ROLES = %w[deactivated banned].freeze
+
+  scope :activated, -> { where(role: ACTIVATED_ROLES) }
+  scope :inactive, -> { where(role: INACTIVE_ROLES) }
+
+  def activated?
+    user? || pro? || admin?
+  end
+
+  def inactive?
+    deactivated? || banned?
+  end
+
   def build_scratchpad
     scratchpad || create_scratchpad
   end
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,5 +34,4 @@ class User < ApplicationRecord
   def build_scratchpad
     scratchpad || create_scratchpad
   end
-  
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
   <!-- Main content -->
   <div class="md:col-span-2">
   <%= render "shared/heading", title: "Welcome to speedpastes", description: (safe_join(["Speedpastes is an ", link_to("open-source", "https://github.com/rjoken/speedpastes", class: link_class(variant: :muted), target: "_blank", rel: "noopener"), ", ad-free, invite-only text sharing platform made for speedrunners, diarists, and whoever else needs to jot and share. Paste your notes, ideas, strategies and more, then link to them quickly and easily."])) do %>
-      <% if signed_in? && activated_user?(current_user) %>
+      <% if signed_in? && current_user.activated? %>
           <%= render "shared/createpaste" %>
       <% elsif signed_in? %>
           <div class="p-4 text-sm text-[var(--muted)]">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,8 +2,12 @@
   <!-- Main content -->
   <div class="md:col-span-2">
   <%= render "shared/heading", title: "Welcome to speedpastes", description: (safe_join(["Speedpastes is an ", link_to("open-source", "https://github.com/rjoken/speedpastes", class: link_class(variant: :muted), target: "_blank", rel: "noopener"), ", ad-free, invite-only text sharing platform made for speedrunners, diarists, and whoever else needs to jot and share. Paste your notes, ideas, strategies and more, then link to them quickly and easily."])) do %>
-      <% if signed_in? %>
+      <% if signed_in? && activated_user?(current_user) %>
           <%= render "shared/createpaste" %>
+      <% elsif signed_in? %>
+          <div class="p-4 text-sm text-[var(--muted)]">
+            Your account is currently unable to create new pastes.
+          </div>
       <% else %>
           <div class="p-4 text-sm text-[var(--muted)]">
             Please <%= link_to "log in", login_path, class: link_class %> or <%= link_to "sign up", signup_path, class: link_class %> to create a new paste.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,8 @@
   <body class="min-h-screen bg-[var(--bg)] text-[var(--text)]">
   <% if signed_in? && current_user.banned? %>
     <%= render "shared/banned" %>
+  <% elsif signed_in? && current_user.inactive? %>
+    <%= render "shared/deactivated" %>
   <% end %>
     <%= render "shared/navbar" %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,9 @@
   </head>
 
   <body class="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+  <% if signed_in? && current_user.banned? %>
+    <%= render "shared/banned" %>
+  <% end %>
     <%= render "shared/navbar" %>
 
     <div class="max-w-5xl mx-auto px-4 py-6">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -8,7 +8,7 @@
             <div class="text-xs text-[var(--muted)] font-bold uppercase tracking-wide">Admin</div>
           <% end %>
           <% if @user.pro? %>
-            <div class="text-xs text-[var(--muted)] font-bold uppercase tracking-wide">Pro</div>
+            <div class="text-xs text-[var(--muted)] font-bold uppercase tracking-wide">Supporter</div>
           <% end %>
           <% if @user.banned? %>
             <div class="text-xs text-red-700 font-bold uppercase tracking-wide">Banned</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -10,6 +10,11 @@
           <% if @user.pro? %>
             <div class="text-xs text-[var(--muted)] font-bold uppercase tracking-wide">Pro</div>
           <% end %>
+          <% if @user.banned? %>
+            <div class="text-xs text-red-700 font-bold uppercase tracking-wide">Banned</div>
+          <% elsif @user.inactive? %>
+            <div class="text-xs text-gray-700 font-bold uppercase tracking-wide">Inactive</div>
+          <% end %>
           <div class="text-sm text-center">
             <div class="font-semibold text-[var(--text)]">Member since <%= @user.created_at.strftime("%b %-d, %Y") %></div>
             <div class="font-semibold text-[var(--text)]"><%= @paste_count %> <%= "paste".pluralize(@paste_count) %></div>
@@ -66,10 +71,14 @@
       <% if current_user&.admin? %>
         <div class="mt-4 border border-[var(--border-muted)] bg-[var(--surface2)] p-3">
           <div class="font-bold mb-2">Admin Actions</div>
-          <div class="mt-2 flex flex-wrap gap-2">
-            <%= button_to "Generate 5 invites", admin_user_invite_codes_path(@user.username), method: :post, class: button_class(variant: :default, size: :sm) %>
-            <%= button_to "Remove avatar", admin_user_remove_avatar_path(@user.username), method: :delete, data: { turbo_confirm: "Are you sure you want to remove this user's avatar?" }, class: button_class(variant: :default, size: :sm) %>
-            <%= button_to "Ban user", admin_user_ban_path(@user.username), method: :delete, data: { turbo_confirm: "Are you sure you want to ban this user? This is not reversible." }, class: button_class(variant: :danger, size: :sm) %>
+          <div class="mt-2 flex flex-col gap-2">
+            <%= button_to "Generate 5 invites", admin_user_invite_codes_path(@user.username), method: :post, class: "#{button_class(variant: :default, size: :sm)} w-full" %>
+            <%= button_to "Remove avatar", admin_user_remove_avatar_path(@user.username), method: :delete, data: { turbo_confirm: "Are you sure you want to remove this user's avatar?" }, class: "#{button_class(variant: :default, size: :sm)} w-full" %>
+            <%= button_to "Nuke user", admin_user_nuke_path(@user.username), method: :delete, data: { turbo_confirm: "Are you sure you want to nuke this user? This is not reversible." }, class: "#{button_class(variant: :danger, size: :sm)} w-full" %>
+            <%= form_with url: admin_user_ban_path(@user.username), method: :post, data: {turbo_confirm: "Are you sure you want to ban this user?"}, class: "flex flex-col gap-2" do %>
+              <%= text_field_tag :reason, nil, placeholder: "Ban reason", class: "border border-[var(--border)] px-2 py-1 text-sm w-full bg-[var(--surface)]" %>
+              <%= submit_tag "Ban user", class: "#{button_class(variant: :danger, size: :sm)} w-full" %>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,6 +7,9 @@
           <% if @user.admin? %>
             <div class="text-xs text-[var(--muted)] font-bold uppercase tracking-wide">Admin</div>
           <% end %>
+          <% if @user.pro? %>
+            <div class="text-xs text-[var(--muted)] font-bold uppercase tracking-wide">Pro</div>
+          <% end %>
           <div class="text-sm text-center">
             <div class="font-semibold text-[var(--text)]">Member since <%= @user.created_at.strftime("%b %-d, %Y") %></div>
             <div class="font-semibold text-[var(--text)]"><%= @paste_count %> <%= "paste".pluralize(@paste_count) %></div>

--- a/app/views/shared/_banned.html.erb
+++ b/app/views/shared/_banned.html.erb
@@ -1,0 +1,5 @@
+<div class="border border-red-700 text-white px-4 py-3 flex flex-col items-center justify-center gap-2 bg-[repeating-linear-gradient(135deg,var(--color-red-500)_0px,var(--color-red-500)_12px,var(--color-red-600)_12px,var(--color-red-600)_24px)]">
+    <strong class="font-bold text-xl">Your account has been banned.</strong>
+    <p class="text-md">Reason: <%= current_user.ban_reason.presence || "No reason provided" %></p>
+    <p class="text-sm mt-2">If you believe this was a mistake, you can contact support at <a class="underline" href="mailto:bans@speedpastes.org">bans@speedpastes.org</a>.</p>
+</div>

--- a/app/views/shared/_deactivated.html.erb
+++ b/app/views/shared/_deactivated.html.erb
@@ -1,0 +1,4 @@
+<div class="border border-gray-700 text-white px-4 py-3 flex flex-col items-center justify-center gap-2 bg-[repeating-linear-gradient(135deg,var(--color-gray-500)_0px,var(--color-gray-500)_12px,var(--color-gray-600)_12px,var(--color-gray-600)_24px)]">
+    <strong class="font-bold text-xl">Your account is currently deactivated.</strong>
+    <p class="text-sm mt-2">You must wait for an administrator to activate your account before you will be able to access some functions.</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,8 @@ Rails.application.routes.draw do
     resources :users, param: :username, only: [] do
       post :invite_codes, action: :generate_invite_codes
       get :invite_codes, action: :invite_codes
-      delete :ban
+      post :ban
+      delete :nuke
       delete :remove_avatar
     end
   end

--- a/db/migrate/20260303234231_add_ban_reason_to_users.rb
+++ b/db/migrate/20260303234231_add_ban_reason_to_users.rb
@@ -1,0 +1,5 @@
+class AddBanReasonToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :ban_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_28_155159) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_03_234231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -266,6 +266,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_28_155159) do
 
   create_table "users", force: :cascade do |t|
     t.datetime "anonymized_at"
+    t.text "ban_reason"
     t.text "bio"
     t.datetime "created_at", null: false
     t.string "email", null: false


### PR DESCRIPTION
Previously, the ban button was actually a nuke button, deleting their account and all of their content. Quick and dirty. Now with this we can keep the account have it in a banned state, displaying a ban reason to the user.